### PR TITLE
Fix teacher class query within academy scope

### DIFF
--- a/src/EduConnect.Api/Abstractions/IClassRepository.cs
+++ b/src/EduConnect.Api/Abstractions/IClassRepository.cs
@@ -9,6 +9,6 @@ public interface IClassRepository
     ValueTask<Class> CreateAsync(Class @class, CancellationToken cancellationToken = default);
     ValueTask<Class> UpdateAsync(Guid id, Class @class, CancellationToken cancellationToken = default);
     ValueTask<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
-    ValueTask<IEnumerable<Class>> GetByAcademyIdAsync(Guid academyId, CancellationToken cancellationToken = default);
+    ValueTask<IEnumerable<Class>> GetAllByAcademyIdAsync(Guid academyId, CancellationToken cancellationToken = default);
     // ValueTask<IEnumerable<Class>> GetByTeacherIdAsync(Guid academyId, Guid teacherId, CancellationToken cancellationToken = default);
 }

--- a/src/EduConnect.Api/Abstractions/IClassesService.cs
+++ b/src/EduConnect.Api/Abstractions/IClassesService.cs
@@ -4,10 +4,11 @@ namespace EduConnect.Api.Abstractions;
 
 public interface IClassesService
 {
-    ValueTask<IEnumerable<Class>> GetAllClassesAsync(CancellationToken cancellationToken = default);
+    // ValueTask<IEnumerable<Class>> GetAllClassesAsync(CancellationToken cancellationToken = default);
     ValueTask<Class> GetClassByIdAsync(Guid id, CancellationToken cancellationToken = default);
     ValueTask<Class> CreateClassAsync(Class @class, CancellationToken cancellationToken = default);
     ValueTask<Class> UpdateClassAsync(Guid id, Class @class, CancellationToken cancellationToken = default);
     ValueTask<bool> DeleteClassAsync(Guid id, CancellationToken cancellationToken = default);
     ValueTask<IEnumerable<Class>> GetClassesByAcademyAsync(Guid academyId, CancellationToken cancellationToken = default);
+    ValueTask<IEnumerable<Class>> GetClassesByTeacherAsync(Guid academyId, Guid teacherId, CancellationToken cancellationToken = default);
 }

--- a/src/EduConnect.Api/Controllers/ClassesController.cs
+++ b/src/EduConnect.Api/Controllers/ClassesController.cs
@@ -48,16 +48,15 @@ public class ClassesController(
     [HttpGet("my-classes")]
     public async ValueTask<IActionResult> GetTeachersClassesAsync(CancellationToken abortionToken = default)
     {
-        var teacherId = JwtClaimHelper.GetUserIdFromToken(User);
-        // var teacherId = GetUserIdFromToken();
-        Console.WriteLine(teacherId!.Value);
+        var teacherId = GetUserIdFromToken()!;
+        var academyId = GetAcademyIdFromToken()!;
+        // Console.WriteLine(teacherId.Value);
 
         if (teacherId == null)
             return Forbid("You do not have permission to access this resource.");
 
-        var classes = await classesService.GetAllClassesAsync(abortionToken);
+        var classes = await classesService.GetClassesByTeacherAsync(academyId.Value, teacherId.Value, abortionToken);
         return Ok(classes.Where(c => c.TeacherId == teacherId.Value).Select(c => c.ToDto()));
-        // return Ok(classes.Select(c => c.ToDto()));
     }
 
     [Authorize(Roles = "Admin")]

--- a/src/EduConnect.Api/Controllers/GetUserAndAcademyIdController.cs
+++ b/src/EduConnect.Api/Controllers/GetUserAndAcademyIdController.cs
@@ -1,0 +1,33 @@
+using System.IdentityModel.Tokens.Jwt;
+using EduConnect.Api.Utilities;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EduConnect.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class GetUserAndAcademyIdController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get(CancellationToken abortionToken = default)
+    {
+        // var userId = JwtClaimHelper.GetUserIdFromToken(User);
+        var userId = GetUserIdFromToken();
+        var academyId = JwtClaimHelper.GetAcademyIdFromToken(User);
+        return Ok(new { userId, academyId });
+    }
+
+    private Guid? GetUserIdFromToken()
+    {
+        var idClaim = User.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Sub)?.Value;
+        return Guid.TryParse(idClaim, out var id) ? id : null;
+    }
+}
+
+/*
+public static Guid? GetUserIdFromToken(ClaimsPrincipal user)
+    {
+        var idClaim = user.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Sub)?.Value;
+        return Guid.TryParse(idClaim, out var id) ? id : null;
+    }
+*/

--- a/src/EduConnect.Api/Program.cs
+++ b/src/EduConnect.Api/Program.cs
@@ -38,6 +38,7 @@ builder.Services.AddScoped<IValidator<LoginRequest>, LoginRequestValidator>();
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
+        options.MapInboundClaims = false;
         options.TokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuer = true,

--- a/src/EduConnect.Api/Repositories/ClassRepository.cs
+++ b/src/EduConnect.Api/Repositories/ClassRepository.cs
@@ -27,7 +27,7 @@ public class ClassRepository(IEduConnectDbContext context) : IClassRepository
     public async ValueTask<IEnumerable<Class>> GetAllAsync(CancellationToken cancellationToken = default)
         => await context.Classes.AsNoTracking().ToListAsync(cancellationToken);
 
-    public async ValueTask<IEnumerable<Class>> GetByAcademyIdAsync(Guid academyId, CancellationToken cancellationToken = default)
+    public async ValueTask<IEnumerable<Class>> GetAllByAcademyIdAsync(Guid academyId, CancellationToken cancellationToken = default)
     {
         return await context.Classes
             .Where(c => c.AcademyId == academyId)

--- a/src/EduConnect.Api/Services/ClassesService.cs
+++ b/src/EduConnect.Api/Services/ClassesService.cs
@@ -8,8 +8,16 @@ namespace EduConnect.Api.Services;
 public class ClassesService(
     IClassRepository classRepository) : IClassesService
 {
-    public async ValueTask<IEnumerable<Class>> GetAllClassesAsync(CancellationToken cancellationToken = default) =>
-        await classRepository.GetAllAsync(cancellationToken);
+    public async ValueTask<IEnumerable<Class>> GetClassesByAcademyAsync(Guid academyId, CancellationToken cancellationToken = default)
+    {
+        return await classRepository.GetAllByAcademyIdAsync(academyId, cancellationToken);
+    }
+
+    public async ValueTask<IEnumerable<Class>> GetClassesByTeacherAsync(Guid academyId, Guid teacherId, CancellationToken cancellationToken = default)
+        => (await classRepository.GetAllByAcademyIdAsync(academyId, cancellationToken)).Where(c => c.TeacherId == teacherId).ToList();
+
+    // public async ValueTask<IEnumerable<Class>> GetAllClassesAsync(CancellationToken cancellationToken = default) =>
+    //     await classRepository.GetAllAsync(cancellationToken);
 
     public async ValueTask<Class> GetClassByIdAsync(Guid id, CancellationToken cancellationToken = default) =>
         await classRepository.GetByIdAsync(id, cancellationToken) ?? throw new ClassNotFoundException(id);
@@ -29,10 +37,5 @@ public class ClassesService(
     public ValueTask<Class> UpdateClassAsync(Guid id, Class @class, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
-    }
-
-    public async ValueTask<IEnumerable<Class>> GetClassesByAcademyAsync(Guid academyId, CancellationToken cancellationToken = default)
-    {
-        return await classRepository.GetByAcademyIdAsync(academyId, cancellationToken);
     }
 }


### PR DESCRIPTION
This PR addresses an issue where teachers were unable to retrieve their associated classes within the context of a specific academy. The problem was due to not properly extracting the user id(teacher's id in this case).