### PR TITLE
Restructure interfaces into clearer abstraction folders

### DIFF
--- a/src/EduConnect.Api/Abstractions/RepositoriesAbstractions/IAcademiesRepository.cs
+++ b/src/EduConnect.Api/Abstractions/RepositoriesAbstractions/IAcademiesRepository.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace EduConnect.Api.Abstractions;
+namespace EduConnect.Api.Abstractions.RepositoriesAbstractions;
 
 public interface IAcademyRepository
 {

--- a/src/EduConnect.Api/Abstractions/RepositoriesAbstractions/IClassRepository.cs
+++ b/src/EduConnect.Api/Abstractions/RepositoriesAbstractions/IClassRepository.cs
@@ -1,6 +1,6 @@
 using EduConnect.Api.Entities;
 
-namespace EduConnect.Api.Abstractions;
+namespace EduConnect.Api.Abstractions.RepositoriesAbstractions;
 
 public interface IClassRepository
 {

--- a/src/EduConnect.Api/Abstractions/RepositoriesAbstractions/IStudentsRepository.cs
+++ b/src/EduConnect.Api/Abstractions/RepositoriesAbstractions/IStudentsRepository.cs
@@ -1,6 +1,6 @@
 using EduConnect.Api.Entities;
 
-namespace EduConnect.Api.Abstractions;
+namespace EduConnect.Api.Abstractions.RepositoriesAbstractions;
 
 public interface IStudentsRepository
 {

--- a/src/EduConnect.Api/Abstractions/RepositoriesAbstractions/ITeacherRepository.cs
+++ b/src/EduConnect.Api/Abstractions/RepositoriesAbstractions/ITeacherRepository.cs
@@ -1,6 +1,6 @@
 using EduConnect.Api.Entities;
 
-namespace EduConnect.Api.Abstractions;
+namespace EduConnect.Api.Abstractions.RepositoriesAbstractions;
 
 public interface ITeacherRepository
 {

--- a/src/EduConnect.Api/Abstractions/RepositoriesAbstractions/ITokensForTeachersRepository.cs
+++ b/src/EduConnect.Api/Abstractions/RepositoriesAbstractions/ITokensForTeachersRepository.cs
@@ -1,6 +1,6 @@
 using EduConnect.Api.Entities;
 
-namespace EduConnect.Api.Abstractions;
+namespace EduConnect.Api.Abstractions.RepositoriesAbstractions;
 
 public interface ITokensForTeachersRepository
 {

--- a/src/EduConnect.Api/Abstractions/RepositoriesAbstractions/IUserRepository.cs
+++ b/src/EduConnect.Api/Abstractions/RepositoriesAbstractions/IUserRepository.cs
@@ -1,6 +1,6 @@
 using EduConnect.Api.Entities;
 
-namespace EduConnect.Api.Repositories;
+namespace EduConnect.Api.Abstractions.RepositoriesAbstractions;
 
 public interface IUserRepository
 {

--- a/src/EduConnect.Api/Abstractions/ServicesAbstractions/IAcademiesService.cs
+++ b/src/EduConnect.Api/Abstractions/ServicesAbstractions/IAcademiesService.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace EduConnect.Api.Abstractions;
+namespace EduConnect.Api.Abstractions.ServicesAbstractions;
 
 public interface IAcademiesService
 {

--- a/src/EduConnect.Api/Abstractions/ServicesAbstractions/IAuthService.cs
+++ b/src/EduConnect.Api/Abstractions/ServicesAbstractions/IAuthService.cs
@@ -1,7 +1,7 @@
 using EduConnect.Api.Dtos;
 using EduConnect.Api.Entities;
 
-namespace EduConnect.Api.Abstractions;
+namespace EduConnect.Api.Abstractions.ServicesAbstractions;
 
 public interface IAuthService
 {

--- a/src/EduConnect.Api/Abstractions/ServicesAbstractions/IClassesService.cs
+++ b/src/EduConnect.Api/Abstractions/ServicesAbstractions/IClassesService.cs
@@ -1,6 +1,6 @@
 using EduConnect.Api.Entities;
 
-namespace EduConnect.Api.Abstractions;
+namespace EduConnect.Api.Abstractions.ServicesAbstractions;
 
 public interface IClassesService
 {

--- a/src/EduConnect.Api/Abstractions/ServicesAbstractions/IStudentsService.cs
+++ b/src/EduConnect.Api/Abstractions/ServicesAbstractions/IStudentsService.cs
@@ -1,6 +1,6 @@
 using EduConnect.Api.Entities;
 
-namespace EduConnect.Api.Abstractions;
+namespace EduConnect.Api.Abstractions.ServicesAbstractions;
 
 public interface IStudentsService
 {

--- a/src/EduConnect.Api/Abstractions/ServicesAbstractions/ITeachersService.cs
+++ b/src/EduConnect.Api/Abstractions/ServicesAbstractions/ITeachersService.cs
@@ -1,6 +1,6 @@
 using EduConnect.Api.Entities;
 
-namespace EduConnect.Api.Abstractions;
+namespace EduConnect.Api.Abstractions.ServicesAbstractions;
 
 public interface ITeachersService
 {

--- a/src/EduConnect.Api/Abstractions/ServicesAbstractions/ITokensForTeachersService.cs
+++ b/src/EduConnect.Api/Abstractions/ServicesAbstractions/ITokensForTeachersService.cs
@@ -1,4 +1,4 @@
-namespace EduConnect.Api.Abstractions;
+namespace EduConnect.Api.Abstractions.ServicesAbstractions;
 
 public interface ITokensForTeachersService
 {

--- a/src/EduConnect.Api/Controllers/AcademiesController.cs
+++ b/src/EduConnect.Api/Controllers/AcademiesController.cs
@@ -1,9 +1,7 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.ServicesAbstractions;
 using EduConnect.Api.Dtos.AcademyDtos;
-using EduConnect.Api.Entities;
 using EduConnect.Api.Exceptions;
 using EduConnect.Api.Mappers.AcademyMappers;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace EduConnect.Api.Controllers;

--- a/src/EduConnect.Api/Controllers/AuthController.cs
+++ b/src/EduConnect.Api/Controllers/AuthController.cs
@@ -1,6 +1,6 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
+using EduConnect.Api.Abstractions.ServicesAbstractions;
 using EduConnect.Api.Dtos;
-using EduConnect.Api.Repositories;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/EduConnect.Api/Controllers/ClassesController.cs
+++ b/src/EduConnect.Api/Controllers/ClassesController.cs
@@ -1,9 +1,8 @@
 using System.IdentityModel.Tokens.Jwt;
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.ServicesAbstractions;
 using EduConnect.Api.Dtos.ClassDtos;
 using EduConnect.Api.Exceptions;
 using EduConnect.Api.Mappers.ClassMappers;
-using EduConnect.Api.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/EduConnect.Api/Controllers/StudentsController.cs
+++ b/src/EduConnect.Api/Controllers/StudentsController.cs
@@ -1,4 +1,4 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.ServicesAbstractions;
 using EduConnect.Api.Dtos.StudentDtos;
 using EduConnect.Api.Exceptions;
 using EduConnect.Api.Mappers.StudentMappers;

--- a/src/EduConnect.Api/Controllers/TeachersController.cs
+++ b/src/EduConnect.Api/Controllers/TeachersController.cs
@@ -1,4 +1,4 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.ServicesAbstractions;
 using EduConnect.Api.Exceptions;
 using EduConnect.Api.Mappers.TeacherMappers;
 using EduConnect.Api.Utilities;

--- a/src/EduConnect.Api/Controllers/TokensForTeachersController.cs
+++ b/src/EduConnect.Api/Controllers/TokensForTeachersController.cs
@@ -1,4 +1,4 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.ServicesAbstractions;
 using EduConnect.Api.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -8,7 +8,8 @@ namespace EduConnect.Api.Controllers;
 [Authorize(Roles = "Admin")]
 [ApiController]
 [Route("api/[controller]")]
-public class TokensForTeachersController(ITokensForTeachersService tokenService) : ControllerBase
+public class TokensForTeachersController(
+    ITokensForTeachersService tokenService) : ControllerBase
 {
     [HttpPost("generate")]
     public async Task<IActionResult> GenerateTokenAsync(CancellationToken abortionToken = default)

--- a/src/EduConnect.Api/Program.cs
+++ b/src/EduConnect.Api/Program.cs
@@ -1,5 +1,6 @@
 using System.Text;
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
+using EduConnect.Api.Abstractions.ServicesAbstractions;
 using EduConnect.Api.Data;
 using EduConnect.Api.Dtos;
 using EduConnect.Api.Repositories;

--- a/src/EduConnect.Api/Repositories/AcademyRepository.cs
+++ b/src/EduConnect.Api/Repositories/AcademyRepository.cs
@@ -1,4 +1,4 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
 using EduConnect.Api.Data;
 using EduConnect.Api.Entities;
 using EduConnect.Api.Exceptions;

--- a/src/EduConnect.Api/Repositories/ClassRepository.cs
+++ b/src/EduConnect.Api/Repositories/ClassRepository.cs
@@ -1,4 +1,4 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
 using EduConnect.Api.Data;
 using EduConnect.Api.Entities;
 using Microsoft.EntityFrameworkCore;

--- a/src/EduConnect.Api/Repositories/StudentsRepository.cs
+++ b/src/EduConnect.Api/Repositories/StudentsRepository.cs
@@ -1,4 +1,4 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
 using EduConnect.Api.Data;
 using EduConnect.Api.Entities;
 using EduConnect.Api.Exceptions;

--- a/src/EduConnect.Api/Repositories/TeacherRepository.cs
+++ b/src/EduConnect.Api/Repositories/TeacherRepository.cs
@@ -1,4 +1,4 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
 using EduConnect.Api.Data;
 using EduConnect.Api.Entities;
 using EduConnect.Api.Exceptions;

--- a/src/EduConnect.Api/Repositories/TokensForTeachersRepository.cs
+++ b/src/EduConnect.Api/Repositories/TokensForTeachersRepository.cs
@@ -1,8 +1,7 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
 using EduConnect.Api.Data;
 using EduConnect.Api.Entities;
 using EduConnect.Api.Utilities;
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 
 namespace EduConnect.Api.Repositories;

--- a/src/EduConnect.Api/Repositories/UserRepository.cs
+++ b/src/EduConnect.Api/Repositories/UserRepository.cs
@@ -1,3 +1,4 @@
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
 using EduConnect.Api.Data;
 using EduConnect.Api.Entities;
 using Microsoft.EntityFrameworkCore;

--- a/src/EduConnect.Api/Services/AcademiesService.cs
+++ b/src/EduConnect.Api/Services/AcademiesService.cs
@@ -1,11 +1,7 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
+using EduConnect.Api.Abstractions.ServicesAbstractions;
 using EduConnect.Api.Entities;
 using EduConnect.Api.Exceptions;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace EduConnect.Api.Services;
 

--- a/src/EduConnect.Api/Services/AuthService.cs
+++ b/src/EduConnect.Api/Services/AuthService.cs
@@ -1,10 +1,10 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
+using EduConnect.Api.Abstractions.ServicesAbstractions;
 using EduConnect.Api.Dtos;
 using EduConnect.Api.Entities;
-using EduConnect.Api.Repositories;
 using Microsoft.IdentityModel.Tokens;
 
 namespace EduConnect.Api.Services;

--- a/src/EduConnect.Api/Services/ClassesService.cs
+++ b/src/EduConnect.Api/Services/ClassesService.cs
@@ -1,7 +1,7 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
+using EduConnect.Api.Abstractions.ServicesAbstractions;
 using EduConnect.Api.Entities;
 using EduConnect.Api.Exceptions;
-using Microsoft.Extensions.Logging;
 
 namespace EduConnect.Api.Services;
 

--- a/src/EduConnect.Api/Services/StudentsService.cs
+++ b/src/EduConnect.Api/Services/StudentsService.cs
@@ -1,4 +1,5 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
+using EduConnect.Api.Abstractions.ServicesAbstractions;
 using EduConnect.Api.Entities;
 using EduConnect.Api.Exceptions;
 

--- a/src/EduConnect.Api/Services/TeachersService.cs
+++ b/src/EduConnect.Api/Services/TeachersService.cs
@@ -1,4 +1,5 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
+using EduConnect.Api.Abstractions.ServicesAbstractions;
 using EduConnect.Api.Entities;
 using EduConnect.Api.Exceptions;
 

--- a/src/EduConnect.Api/Services/TokensForTeachers.cs
+++ b/src/EduConnect.Api/Services/TokensForTeachers.cs
@@ -1,4 +1,5 @@
-using EduConnect.Api.Abstractions;
+using EduConnect.Api.Abstractions.RepositoriesAbstractions;
+using EduConnect.Api.Abstractions.ServicesAbstractions;
 
 namespace EduConnect.Api.Services;
 


### PR DESCRIPTION
This PR improves project structure by organizing the Abstractions folder into two distinct subfolders:
ServicesAbstractions for service-related interfaces
RepositoriesAbstractions for repository-related interfaces
Enhances codebase clarity and separation of concerns
No logic/functionality changes